### PR TITLE
iCal bug fixes

### DIFF
--- a/server/api/integrations/[id].put.ts
+++ b/server/api/integrations/[id].put.ts
@@ -4,6 +4,7 @@ import { createError, defineEventHandler, readBody } from "h3";
 
 import { createIntegrationService, integrationRegistry } from "~/types/integrations";
 
+import { normalizeWebcalUrl } from "../../utils/icalUrl";
 import { sanitizeIntegration } from "../../utils/sanitizeIntegration";
 
 const prisma = new PrismaClient();
@@ -19,7 +20,11 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = await readBody(event);
-    const { name, type, service, apiKey, baseUrl, icon, enabled, settings } = body;
+    const { name, type, service, apiKey, icon, enabled, settings } = body;
+    let baseUrl = body.baseUrl;
+    if (baseUrl && typeof baseUrl === "string") {
+      baseUrl = normalizeWebcalUrl(baseUrl);
+    }
     let preservedSettings = settings;
 
     if (apiKey || baseUrl || settings) {

--- a/server/api/integrations/index.post.ts
+++ b/server/api/integrations/index.post.ts
@@ -4,6 +4,7 @@ import { createError, defineEventHandler, readBody } from "h3";
 
 import { createIntegrationService, integrationRegistry } from "~/types/integrations";
 
+import { normalizeWebcalUrl } from "../../utils/icalUrl";
 import { sanitizeIntegration } from "../../utils/sanitizeIntegration";
 
 const prisma = new PrismaClient();
@@ -11,7 +12,11 @@ const prisma = new PrismaClient();
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody(event);
-    const { name, type, service, apiKey, baseUrl, icon, enabled, settings } = body;
+    const { name, type, service, apiKey, icon, enabled, settings } = body;
+    let baseUrl = body.baseUrl;
+    if (baseUrl && typeof baseUrl === "string") {
+      baseUrl = normalizeWebcalUrl(baseUrl);
+    }
 
     const integrationKey = `${type}:${service}`;
 

--- a/server/integrations/iCal/client.ts
+++ b/server/integrations/iCal/client.ts
@@ -41,9 +41,23 @@ export class ICalServerService {
     const startUTC = dtstart
       ? dtstart.convertToZone(ical.TimezoneService.get("UTC")).toString()
       : new Date().toISOString().replace(".000", "");
-    const endUTC = dtend
-      ? dtend.convertToZone(ical.TimezoneService.get("UTC")).toString()
-      : new Date().toISOString().replace(".000", "");
+
+    let endUTC: string;
+    if (dtend) {
+      endUTC = dtend.convertToZone(ical.TimezoneService.get("UTC")).toString();
+    }
+    else if (dtstart?.isDate) {
+      const startDate = dtstart.convertToZone(ical.TimezoneService.get("UTC")).toJSDate();
+      const endDate = new Date(Date.UTC(
+        startDate.getUTCFullYear(),
+        startDate.getUTCMonth(),
+        startDate.getUTCDate() + 1,
+      ));
+      endUTC = ical.Time.fromJSDate(endDate, true).toString();
+    }
+    else {
+      endUTC = startUTC;
+    }
 
     return {
       type: "VEVENT",

--- a/server/utils/icalUrl.ts
+++ b/server/utils/icalUrl.ts
@@ -1,0 +1,10 @@
+export function normalizeWebcalUrl(url: string): string {
+  if (!url || typeof url !== "string")
+    return url;
+  const lower = url.toLowerCase();
+  if (lower.startsWith("webcal://"))
+    return `http://${url.slice(9)}`;
+  if (lower.startsWith("webcals://"))
+    return `https://${url.slice(10)}`;
+  return url;
+}

--- a/test/unit/server/integrations/iCal/client.test.ts
+++ b/test/unit/server/integrations/iCal/client.test.ts
@@ -95,6 +95,40 @@ describe("ICalServerService", () => {
     expect(parsed).toBeDefined();
   });
 
+  it("should set dtend to start of next day when all-day event has no DTEND (RFC 5545)", () => {
+    const vevent = new ical.Component(["vevent", [], []]);
+    vevent.addPropertyWithValue("uid", "test-event-all-day-no-dtend");
+    vevent.addPropertyWithValue("summary", "Weather Forecast Feb 5");
+    vevent.addPropertyWithValue("dtstart", ical.Time.fromData({
+      year: 2026,
+      month: 2,
+      day: 5,
+      isDate: true,
+    }));
+
+    const parsed = service["parseICalEvent"](vevent);
+    expect(parsed).toBeDefined();
+    expect(parsed.dtstart).toBeDefined();
+    expect(parsed.dtend).toBeDefined();
+
+    const startDate = new Date(parsed.dtstart);
+    const endDate = new Date(parsed.dtend);
+
+    expect(startDate.getUTCFullYear()).toBe(2026);
+    expect(startDate.getUTCMonth()).toBe(1);
+    expect(startDate.getUTCDate()).toBe(5);
+    expect(startDate.getUTCHours()).toBe(0);
+    expect(startDate.getUTCMinutes()).toBe(0);
+    expect(startDate.getUTCSeconds()).toBe(0);
+
+    expect(endDate.getUTCFullYear()).toBe(2026);
+    expect(endDate.getUTCMonth()).toBe(1);
+    expect(endDate.getUTCDate()).toBe(6);
+    expect(endDate.getUTCHours()).toBe(0);
+    expect(endDate.getUTCMinutes()).toBe(0);
+    expect(endDate.getUTCSeconds()).toBe(0);
+  });
+
   it("should detect midnight-to-midnight boundary for all-day events", () => {
     const vevent = new ical.Component(["vevent", [], []]);
     vevent.addPropertyWithValue("uid", "test-event-4");

--- a/test/unit/server/utils/icalUrl.test.ts
+++ b/test/unit/server/utils/icalUrl.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeWebcalUrl } from "../../../../server/utils/icalUrl";
+
+describe("normalizeWebcalUrl", () => {
+  it("converts webcal:// to http://", () => {
+    expect(normalizeWebcalUrl("webcal://example.com/calendar.ics")).toBe("http://example.com/calendar.ics");
+  });
+
+  it("converts webcals:// to https://", () => {
+    expect(normalizeWebcalUrl("webcals://example.com/calendar.ics")).toBe("https://example.com/calendar.ics");
+  });
+
+  it("handles WEBCAL:// case insensitively", () => {
+    expect(normalizeWebcalUrl("WEBCAL://example.com/cal.ics")).toBe("http://example.com/cal.ics");
+  });
+
+  it("handles WEBCALS:// case insensitively", () => {
+    expect(normalizeWebcalUrl("WEBCALS://example.com/cal.ics")).toBe("https://example.com/cal.ics");
+  });
+
+  it("leaves https:// unchanged", () => {
+    expect(normalizeWebcalUrl("https://example.com/calendar.ics")).toBe("https://example.com/calendar.ics");
+  });
+
+  it("leaves http:// unchanged", () => {
+    expect(normalizeWebcalUrl("http://example.com/calendar.ics")).toBe("http://example.com/calendar.ics");
+  });
+
+  it("returns empty string as-is", () => {
+    expect(normalizeWebcalUrl("")).toBe("");
+  });
+
+  it("returns non-string input as-is", () => {
+    expect(normalizeWebcalUrl(null as unknown as string)).toBe(null);
+    expect(normalizeWebcalUrl(undefined as unknown as string)).toBe(undefined);
+  });
+});


### PR DESCRIPTION
handle ics missing DTEND
add: normalize webcal URL
add: tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar integration URLs with webcal:// and webcals:// protocols are now automatically converted to standard http:// and https:// formats.

* **Bug Fixes**
  * All-day calendar events now correctly calculate end times, properly handling events without explicit end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->